### PR TITLE
removed the "@" from the styles.xml for animations

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -21,16 +21,16 @@
 
     <style name="animDialogPushUp" parent="android:Animation">
         <!-- 进入时的动画 -->
-        <item name="@android:windowEnterAnimation">@anim/push_up_in</item>
+        <item name="android:windowEnterAnimation">@anim/push_up_in</item>
         <!-- 退出时的动画 -->
-        <item name="@android:windowExitAnimation">@anim/push_down_out</item>
+        <item name="android:windowExitAnimation">@anim/push_down_out</item>
     </style>
 
     <style name="animDialogPushDown" parent="android:Animation">
         <!-- 进入时的动画 -->
-        <item name="@android:windowEnterAnimation">@anim/push_down_in</item>
+        <item name="android:windowEnterAnimation">@anim/push_down_in</item>
         <!-- 退出时的动画 -->
-        <item name="@android:windowExitAnimation">@anim/push_up_out</item>
+        <item name="android:windowExitAnimation">@anim/push_up_out</item>
     </style>
 
     <!-- 进度对话框风格 -->


### PR DESCRIPTION
Updated for Gradle plugin 3.0.0 migration

https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#at_symbol

> Incorrect use of @ resource reference symbols
AAPT2 now throws build errors when you omit or incorrectly place resource reference symbols (@).